### PR TITLE
#240: JWTの本当の有効性を確認

### DIFF
--- a/src/libs/auth/admin_auth.ts
+++ b/src/libs/auth/admin_auth.ts
@@ -15,6 +15,20 @@ function getJWT(): JWT | null {
   return jwt;
 }
 
+function strictValidateJWT(client: AspidaClient<AxiosRequestConfig>) {
+  const jwt = getJWT();
+  if (jwt === null) return Promise.resolve(false);
+  return new Promise((s) => {
+    api(client)
+      .admin.user.$get({ headers: { "X-ADMIN-TOKEN": jwt.content } })
+      .then(() => s(true))
+      .catch(() => {
+        Cookie.remove("admin_token");
+        s(false);
+      });
+  });
+}
+
 function attempt_get_JWT(): Promise<JWT> {
   return new Promise((s, r) => {
     const ret = getJWT();
@@ -66,4 +80,11 @@ function change_password(
     });
 }
 
-export default { getJWT, login, logout, change_password, attempt_get_JWT };
+export default {
+  getJWT,
+  strictValidateJWT,
+  login,
+  logout,
+  change_password,
+  attempt_get_JWT,
+};

--- a/src/libs/auth/writer_auth.ts
+++ b/src/libs/auth/writer_auth.ts
@@ -15,6 +15,20 @@ function getJWT(): JWT | null {
   return jwt;
 }
 
+function strictValidateJWT(client: AspidaClient<AxiosRequestConfig>) {
+  const jwt = getJWT();
+  if (jwt === null) return Promise.resolve(false);
+  return new Promise((s) => {
+    api(client)
+      .writer.user.$get({ headers: { "X-BLOG-WRITER-TOKEN": jwt.content } })
+      .then(() => s(true))
+      .catch(() => {
+        Cookie.remove("writer_token");
+        s(false);
+      });
+  });
+}
+
 function attempt_get_JWT(): Promise<JWT> {
   return new Promise((s, r) => {
     const ret = getJWT();
@@ -66,4 +80,11 @@ function change_password(
     });
 }
 
-export default { getJWT, login, logout, change_password, attempt_get_JWT };
+export default {
+  getJWT,
+  strictValidateJWT,
+  login,
+  logout,
+  change_password,
+  attempt_get_JWT,
+};

--- a/src/views/blog/admin/admin_top.vue
+++ b/src/views/blog/admin/admin_top.vue
@@ -148,8 +148,12 @@ export default class AdminTop extends Vue {
   }
 
   admin_login() {
-    AdminAuth.attempt_get_JWT().then(() => {
-      this.load();
+    AdminAuth.strictValidateJWT(aspida()).then((is_valid) => {
+      if (!is_valid) {
+        AdminAuth.attempt_get_JWT().then(() => {
+          this.load();
+        });
+      }
     });
   }
 
@@ -159,8 +163,12 @@ export default class AdminTop extends Vue {
   }
 
   writer_login() {
-    WriterAuth.attempt_get_JWT().then(() => {
-      this.load();
+    WriterAuth.strictValidateJWT(aspida()).then((is_valid) => {
+      if (!is_valid) {
+        WriterAuth.attempt_get_JWT().then(() => {
+          this.load();
+        });
+      }
     });
   }
 


### PR DESCRIPTION
ログインボタンを押下したときにリクエストを飛ばして確認できるようにした