### PR TITLE
#306 記事一覧に読むのにかかる時間を表示した

### DIFF
--- a/src/libs/markdown.ts
+++ b/src/libs/markdown.ts
@@ -56,7 +56,7 @@ export function render_plaintext(md: string) {
         if (token.block) {
           if (token.children !== null)
             // children may be null despite the type definition
-            return tokens2txt(token.children) + " ";
+            return tokens2txt(token.children) + "<br>";
           else return "";
         }
         return token.content;

--- a/src/libs/markdown.ts
+++ b/src/libs/markdown.ts
@@ -68,6 +68,7 @@ export function render_plaintext(md: string) {
 
 export function time_to_read(md: string) {
   return Math.ceil(render_plaintext(md).length / 400);
+  // return minute to read
 }
 
 export default {

--- a/src/libs/markdown.ts
+++ b/src/libs/markdown.ts
@@ -66,9 +66,9 @@ export function render_plaintext(md: string) {
   return tokens2txt(tokens);
 }
 
+// return minute to read
 export function time_to_read(md: string) {
   return Math.ceil(render_plaintext(md).length / 400);
-  // return minute to read
 }
 
 export default {

--- a/src/libs/markdown.ts
+++ b/src/libs/markdown.ts
@@ -56,7 +56,7 @@ export function render_plaintext(md: string) {
         if (token.block) {
           if (token.children !== null)
             // children may be null despite the type definition
-            return tokens2txt(token.children) + "<br>";
+            return tokens2txt(token.children) + " ";
           else return "";
         }
         return token.content;

--- a/src/libs/markdown.ts
+++ b/src/libs/markdown.ts
@@ -66,9 +66,14 @@ export function render_plaintext(md: string) {
   return tokens2txt(tokens);
 }
 
+export function time_to_read(md: string) {
+  return Math.ceil(render_plaintext(md).length / 400);
+}
+
 export default {
   Markdown,
   render,
   get_first_image,
   render_plaintext,
+  time_to_read,
 };

--- a/src/views/blog/admin/new_revision.vue
+++ b/src/views/blog/admin/new_revision.vue
@@ -51,6 +51,10 @@
             <font-awesome-icon :icon="'clock'" class="fa-fw" />
             yyyy/mm/dd
           </span>
+          <span>
+            <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
+            {{ time_to_read }} 分
+          </span>
         </div>
         <div v-html="rendered_content"></div>
         <hr />
@@ -71,6 +75,10 @@
             <span>
               <font-awesome-icon :icon="'clock'" class="fa-fw" />
               yyyy/mm/dd
+            </span>
+            <span>
+              <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
+              {{ time_to_read }} 分
             </span>
           </b-card-sub-title>
           <b-card-text v-html="card_text" />
@@ -362,6 +370,10 @@ export default class NewRevision extends Vue {
     });
     decoded = decoded.replace(/\n/g, "");
     return decoded;
+  }
+
+  get time_to_read() {
+    return Math.ceil(Markdown.render_plaintext(this.content).length / 400);
   }
 }
 </script>

--- a/src/views/blog/admin/new_revision.vue
+++ b/src/views/blog/admin/new_revision.vue
@@ -373,7 +373,7 @@ export default class NewRevision extends Vue {
   }
 
   get time_to_read() {
-    return Math.ceil(Markdown.render_plaintext(this.content).length / 400);
+    return Markdown.time_to_read(this.content);
   }
 }
 </script>

--- a/src/views/blog/admin/new_revision.vue
+++ b/src/views/blog/admin/new_revision.vue
@@ -53,7 +53,7 @@
           </span>
           <span>
             <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
-            {{ time_to_read }} 分
+            約 {{ time_to_read }} 分
           </span>
         </div>
         <div v-html="rendered_content"></div>
@@ -78,7 +78,7 @@
             </span>
             <span>
               <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
-              {{ time_to_read }} 分
+              約 {{ time_to_read }} 分
             </span>
           </b-card-sub-title>
           <b-card-text v-html="card_text" />

--- a/src/views/blog/article_list.vue
+++ b/src/views/blog/article_list.vue
@@ -262,7 +262,7 @@ export default class ArticleList extends Vue {
   }
 
   get_time_to_read(article: BlogArticle) {
-    return Math.ceil(Markdown.render_plaintext(article.content).length / 400);
+    return Markdown.time_to_read(article.content);
   }
 }
 </script>

--- a/src/views/blog/article_list.vue
+++ b/src/views/blog/article_list.vue
@@ -33,6 +33,10 @@
               <font-awesome-icon :icon="'clock'" class="fa-fw" />
               {{ get_updated_at(article) }}
             </span>
+            <span>
+              <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
+              {{ get_time_to_read(article) }} 分
+            </span>
           </b-card-sub-title>
           <b-card-text v-html="get_card_text(article)" />
         </b-card>
@@ -255,6 +259,10 @@ export default class ArticleList extends Vue {
 
   get_updated_at(article: BlogArticle) {
     return getStringDate(article.updated_at);
+  }
+
+  get_time_to_read(article: BlogArticle) {
+    return Math.ceil(Markdown.render_plaintext(article.content).length / 400);
   }
 }
 </script>

--- a/src/views/blog/article_list.vue
+++ b/src/views/blog/article_list.vue
@@ -35,7 +35,7 @@
             </span>
             <span>
               <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
-              {{ get_time_to_read(article) }} 分
+              約 {{ get_time_to_read(article) }} 分
             </span>
           </b-card-sub-title>
           <b-card-text v-html="get_card_text(article)" />

--- a/src/views/blog/new_contrib.vue
+++ b/src/views/blog/new_contrib.vue
@@ -75,6 +75,10 @@
                 <font-awesome-icon :icon="'clock'" class="fa-fw" />
                 yyyy/mm/dd
               </span>
+              <span>
+                <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
+                {{ time_to_read }} 分
+              </span>
             </b-card-sub-title>
             <b-card-text v-html="card_text" />
           </b-card>
@@ -334,6 +338,10 @@ export default class NewRevision extends Vue {
   }
   get_revision_article_id(revision: BlogRevision) {
     return revision.article_id;
+  }
+
+  get time_to_read() {
+    return Math.ceil(Markdown.render_plaintext(this.content).length / 400);
   }
 }
 </script>

--- a/src/views/blog/new_contrib.vue
+++ b/src/views/blog/new_contrib.vue
@@ -341,7 +341,7 @@ export default class NewRevision extends Vue {
   }
 
   get time_to_read() {
-    return Math.ceil(Markdown.render_plaintext(this.content).length / 400);
+    return Markdown.time_to_read(this.content);
   }
 }
 </script>

--- a/src/views/blog/new_contrib.vue
+++ b/src/views/blog/new_contrib.vue
@@ -77,7 +77,7 @@
               </span>
               <span>
                 <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
-                {{ time_to_read }} 分
+                約 {{ time_to_read }} 分
               </span>
             </b-card-sub-title>
             <b-card-text v-html="card_text" />

--- a/src/views/blog/show_article.vue
+++ b/src/views/blog/show_article.vue
@@ -16,6 +16,10 @@
           <font-awesome-icon :icon="'clock'" class="fa-fw" />
           {{ get_updated_at(article) }}
         </span>
+        <span>
+          <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
+          {{ get_time_to_read(article) }} 分
+        </span>
         <b-button-group>
           <b-button
             variant="secondary"
@@ -171,6 +175,10 @@ export default class ShowArticle extends Vue {
 
   get_updated_at(article: BlogArticle) {
     return getStringTime(article.updated_at);
+  }
+
+  get_time_to_read(article: BlogArticle) {
+    return Math.ceil(Markdown.render_plaintext(article.content).length / 400);
   }
 }
 </script>

--- a/src/views/blog/show_article.vue
+++ b/src/views/blog/show_article.vue
@@ -178,7 +178,7 @@ export default class ShowArticle extends Vue {
   }
 
   get_time_to_read(article: BlogArticle) {
-    return Math.ceil(Markdown.render_plaintext(article.content).length / 400);
+    return Markdown.time_to_read(article.content);
   }
 }
 </script>

--- a/src/views/blog/show_article.vue
+++ b/src/views/blog/show_article.vue
@@ -18,7 +18,7 @@
         </span>
         <span>
           <font-awesome-icon :icon="'stopwatch'" class="fa-fw" />
-          {{ get_time_to_read(article) }} 分
+          約 {{ get_time_to_read(article) }} 分
         </span>
         <b-button-group>
           <b-button


### PR DESCRIPTION
resolve: #306 
記事一覧に文字数を出したい問題は、記事一覧に読むのにかかる時間の目安を表示することにしました

初めてVueをまともに触りました

時間表示の際に、「plane_text」を返すやつに<br>タグが混ざってて、previewで使われてることもなかったので、改行→空白に置き換えることにしました