### PR TITLE
#333 403 チェックがあるページの document.title が壊れる不具合を修正

### DIFF
--- a/src/components/Forbidden.vue
+++ b/src/components/Forbidden.vue
@@ -54,9 +54,16 @@ import { Component, Prop, Vue } from "vue-property-decorator";
 
 @Component
 export default class Forbidden extends Vue {
-  readonly page_title = "403 Forbidden";
+  readonly forbidden_title = "403 Forbidden";
 
   @Prop({ required: true, default: false })
   isForbidden = false;
+
+  @Prop({ required: true, default: "" })
+  title?: string;
+
+  get page_title(): string {
+    return this.isForbidden ? this.forbidden_title : this.title || "";
+  }
 }
 </script>

--- a/src/views/blog/admin/manage_path.vue
+++ b/src/views/blog/admin/manage_path.vue
@@ -1,5 +1,5 @@
 <template>
-  <forbidden :is-forbidden="forbidden" class="box wide-box">
+  <forbidden :is-forbidden="forbidden" :title="page_title" class="box wide-box">
     <breadcrumb :text="page_title" />
     <h1>{{ page_title }}</h1>
     <b-button @click="load">

--- a/src/views/blog/admin/new_revision.vue
+++ b/src/views/blog/admin/new_revision.vue
@@ -1,5 +1,5 @@
 <template>
-  <forbidden :is-forbidden="forbidden" class="box wide-box">
+  <forbidden :is-forbidden="forbidden" :title="page_title" class="box wide-box">
     <breadcrumb :text="page_title" />
     <h1>{{ page_title }}</h1>
     <b-form-group label="id:">

--- a/src/views/blog/admin/path_list.vue
+++ b/src/views/blog/admin/path_list.vue
@@ -1,5 +1,10 @@
 <template>
-  <forbidden :is-forbidden="forbidden" id="path-list" class="box wide-box">
+  <forbidden
+    :is-forbidden="forbidden"
+    :title="page_title"
+    id="path-list"
+    class="box wide-box"
+  >
     <breadcrumb :text="page_title" />
     <h1>{{ page_title }}</h1>
     <b-button @click="load">

--- a/src/views/blog/admin/revision_list.vue
+++ b/src/views/blog/admin/revision_list.vue
@@ -1,5 +1,5 @@
 <template>
-  <forbidden :is-forbidden="forbidden" class="box wide-box">
+  <forbidden :is-forbidden="forbidden" :title="page_title" class="box wide-box">
     <breadcrumb :text="page_title" />
     <h1>{{ page_title }}</h1>
     <b-button @click="load">

--- a/src/views/blog/admin/revision_preview.vue
+++ b/src/views/blog/admin/revision_preview.vue
@@ -1,5 +1,5 @@
 <template>
-  <forbidden :is-forbidden="forbidden" id="show-revision">
+  <forbidden :is-forbidden="forbidden" :title="page_title" id="show-revision">
     <template v-if="found_revision">
       <breadcrumb :text="page_title" />
       <b-alert show variant="info">


### PR DESCRIPTION
fix #333 

な阪関無

本来 403 ページって mixin でやるのが正解なんだろうなぁ
React だったらそう実装してた（早期 return）