### PR TITLE
#364 iOS で header が表示されないバグの修正？

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -471,12 +471,14 @@
   #left-wrapper {
     height: auto;
     padding: 0;
+    position: static; // remove position sticky
 
     header {
       display: block;
       height: auto;
       position: fixed; // bug
       top: 0;
+      z-index: 1003;
 
       #top {
         height: 4rem;


### PR DESCRIPTION
fix #364 

wrapper が fixed だったのが原因だった？

モバイルでは wrapper を static にしています
本当は releative とかにしたいけどだめだったので仕方なし